### PR TITLE
Update state by updater function in remove method

### DIFF
--- a/src/StorageProvider.js
+++ b/src/StorageProvider.js
@@ -105,10 +105,8 @@ class StorageProvider extends PureComponent {
    * Remove item from storage
    */
   remove = (key) => {
-    const newState = { ...this.state[STORAGE_KEY], [key]: undefined };
-
-    this.setState({ [STORAGE_KEY]: newState }, async () => {
-      await this.providedStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+    this.setState((prevState) => ({ [STORAGE_KEY]: { ...prevState[STORAGE_KEY], [key]: undefined } }), async () => {
+      await this.providedStorage.setItem(STORAGE_KEY, JSON.stringify(this.state[STORAGE_KEY]));
     });
   };
 


### PR DESCRIPTION
### Problem
When a function is called more than once in succession

`storage.remove('test_1');`
`storage.remove('test_2');`
`...`
`storage.remove('test_N');`

The fields are not deleted or not all are deleted.

This happens because asynchronous calls occur that refer to one state object that has not yet been updated after the previous calls.

### Solution

Update state using the updater function in the method `setState`
